### PR TITLE
Fix custom morph map sort by

### DIFF
--- a/src/Meta/Traits/MetaClauses.php
+++ b/src/Meta/Traits/MetaClauses.php
@@ -431,7 +431,7 @@ trait MetaClauses
         $table = $this->getMetaTable();
         return $query->leftJoin($table . ' as meta' . $this->countOfMetaJoins, function ($q) use ($key) {
             $q->on('meta' . $this->countOfMetaJoins . '.owner_id', '=', $this->getTable() . ".id");
-            $q->where('meta' . $this->countOfMetaJoins . '.owner_type', '=', static::class);
+            $q->where('meta' . $this->countOfMetaJoins . '.owner_type', '=', $this->getMorphClass());
             $q->where('meta' . $this->countOfMetaJoins . '.key', $key);
         })
             ->orderByRaw("CASE (meta" . $this->countOfMetaJoins . ".key)

--- a/tests/Clauses/TestCustomMorphMapOrderBy.php
+++ b/tests/Clauses/TestCustomMorphMapOrderBy.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace Zoha\Meta\Tests\Clauses;
+
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Zoha\Meta\Models\ExampleModel;
+use Zoha\Meta\Tests\TestingHelpers;
+
+class TestCustomMorphMapOrderBy extends TestingHelpers
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Relation::morphMap([
+            'TESTING' => ExampleModel::class,
+        ]);
+        $this->replaceOwnerType('TESTING');
+        $this->modelTruncate();
+        $this->metaTruncate();
+        $this->seeding();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        Relation::$morphMap = [];
+    }
+
+    function test_order_by_meta_with_custom_morph_map()
+    {
+        $results = ExampleModel::orderByMeta('key1', 'desc')->pluck('id')->toArray();
+        $this->assertEquals([4, 2, 3, 1, 5], $results);
+
+        $results = ExampleModel::orderByMeta('key1', 'asc')->pluck('id')->toArray();
+        $this->assertEquals([1, 5, 2, 3, 4], $results);
+
+    }
+}

--- a/tests/TestingHelpers.php
+++ b/tests/TestingHelpers.php
@@ -298,6 +298,15 @@ class TestingHelpers extends TestCase
         }
     }
 
+    public function replaceOwnerType(string $type): void
+    {
+        foreach ($this->fakeDataMeta as $i => $item) {
+            foreach ($item as $j => $meta) {
+                $this->fakeDataMeta[$i][$j]['owner_type'] = $type;
+            }
+        }
+    }
+
     /**
      * delete all meta data from db
      *


### PR DESCRIPTION
Noticed `->sortByMeta` was not working properly in an application where the model has a custom morph map, so here is the fix!

Test  suite all green

`OK (244 tests, 1891 assertions)
`

New test: `\Zoha\Meta\Tests\Clauses\TestCustomMorphMapOrderBy`

New helper method to replace the `owner_type` from the `fakeDataMeta` array, looks a little clumsy but it is the way I managed to get a failing test without rewriting the whole seeder.

```php
public function replaceOwnerType(string $type): void
{
    foreach ($this->fakeDataMeta as $i => $item) {
        foreach ($item as $j => $meta) {
            $this->fakeDataMeta[$i][$j]['owner_type'] = $type;
        }
    }
}
```

Not sure if I should push `.phpunit.result.cache`, so I didn't

